### PR TITLE
chore(Dockerfile): Use docker multi-stage build & add healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,4 @@ VOLUME /var/lib/vnstat
 EXPOSE ${HTTP_PORT}
 
 CMD [ "/start.sh" ]
-HEALTHCHECK --interval=10s --timeout=3s \
-  CMD curl --silent --fail http://localhost:${HTTP_PORT}/ || exit 1
+HEALTHCHECK CMD curl --silent --fail http://localhost:${HTTP_PORT}/ || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,20 +13,19 @@ ENV RATE_UNIT=1
 ENV PAGE_REFRESH=0
 
 RUN true \
-    && set -e \
-    && set -x \
+    && set -ex \
     && apk add --no-cache \
                 gd \
                 perl \
                 lighttpd \
-                sqlite-libs
+                sqlite-libs \
+                curl
 
 
 FROM alpine:latest AS builder
 
 RUN true \
-    && set -e \
-    && set -x \
+    && set -ex \
     && apk add --no-cache \
                 gcc \
                 make \
@@ -49,8 +48,7 @@ COPY --from=builder /usr/sbin/vnstatd /usr/sbin/vnstatd
 COPY --from=builder /etc/vnstat.conf /etc/vnstat.conf
 
 RUN true \
-    && set -e \
-    && set -x \
+    && set -ex \
     && addgroup -S vnstat  \
     && adduser -S -h /var/lib/vnstat -s /sbin/nologin -g vnStat -D -H -G vnstat vnstat
 
@@ -63,4 +61,5 @@ VOLUME /var/lib/vnstat
 EXPOSE ${HTTP_PORT}
 
 CMD [ "/start.sh" ]
-HEALTHCHECK --timeout=10s CMD curl --silent --fail http://127.0.0.1:${HTTP_PORT}/
+HEALTHCHECK --interval=10s --timeout=3s \
+  CMD curl --silent --fail http://localhost:${HTTP_PORT}/ || exit 1

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:latest AS base
 
 LABEL author="Teemu Toivola"
 LABEL repository.git="https://github.com/vergoh/vnstat-docker"
@@ -12,21 +12,54 @@ ENV CACHE_TIME=1
 ENV RATE_UNIT=1
 ENV PAGE_REFRESH=0
 
-RUN apk add --no-cache gcc musl-dev make perl gd gd-dev sqlite-libs sqlite-dev linux-headers lighttpd git && \
-  git clone --depth 1 https://github.com/vergoh/vnstat && \
-  cd vnstat/ && \
-  ./configure --prefix=/usr --sysconfdir=/etc && \
-  make && make install && \
-  cp -v examples/vnstat.cgi /var/www/localhost/htdocs/index.cgi && \
-  cp -v examples/vnstat-json.cgi /var/www/localhost/htdocs/json.cgi && \
-  cd .. && rm -fr vnstat* && \
-  apk del gcc pkgconf gd-dev make musl-dev sqlite-dev linux-headers git && \
-  addgroup -S vnstat && adduser -S -h /var/lib/vnstat -s /sbin/nologin -g vnStat -D -H -G vnstat vnstat
+RUN true \
+    && set -ex \
+    && apk add --no-cache \
+                gd \
+                perl \
+                lighttpd \
+                sqlite-libs \
+                curl
+
+
+FROM alpine:latest AS builder
+
+RUN true \
+    && set -ex \
+    && apk add --no-cache \
+                gcc \
+                make \
+                musl-dev \
+                linux-headers \
+                gd-dev \
+                sqlite-dev \
+                git \
+    && git clone --depth 1 https://github.com/vergoh/vnstat \
+    && cd vnstat \
+    && ./configure --prefix=/usr --sysconfdir=/etc \
+    && make && make install
+
+
+FROM base AS runtime
+
+COPY --from=builder /usr/bin/vnstat /usr/bin/vnstat
+COPY --from=builder /usr/bin/vnstati /usr/bin/vnstati
+COPY --from=builder /usr/sbin/vnstatd /usr/sbin/vnstatd
+COPY --from=builder /etc/vnstat.conf /etc/vnstat.conf
+COPY --from=builder vnstat/examples/vnstat.cgi /var/www/localhost/htdocs/index.cgi
+COPY --from=builder vnstat/examples/vnstat-json.cgi /var/www/localhost/htdocs/json.cgi
+
+RUN true \
+    && set -ex \
+    && addgroup -S vnstat  \
+    && adduser -S -h /var/lib/vnstat -s /sbin/nologin -g vnStat -D -H -G vnstat vnstat
 
 COPY favicon.ico /var/www/localhost/htdocs/favicon.ico
+COPY start.sh /
 
 VOLUME /var/lib/vnstat
 EXPOSE ${HTTP_PORT}
 
-COPY start.sh /
 CMD [ "/start.sh" ]
+HEALTHCHECK --interval=10s --timeout=3s \
+  CMD curl --silent --fail http://localhost:${HTTP_PORT}/ || exit 1

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -61,5 +61,4 @@ VOLUME /var/lib/vnstat
 EXPOSE ${HTTP_PORT}
 
 CMD [ "/start.sh" ]
-HEALTHCHECK --interval=10s --timeout=3s \
-  CMD curl --silent --fail http://localhost:${HTTP_PORT}/ || exit 1
+HEALTHCHECK CMD curl --silent --fail http://localhost:${HTTP_PORT}/ || exit 1


### PR DESCRIPTION
Use docker multi-stage, put frequently modified files such as *.cgi in the lower part, and make full use of the cache to shorten the build time. Add runtime health check.